### PR TITLE
refactor: remove unused optparse configurations in testing

### DIFF
--- a/test_samples.py
+++ b/test_samples.py
@@ -6,14 +6,7 @@ import optparse
 from loginform import fill_login_form
 
 
-def parse_opts():
-    op = optparse.OptionParser(usage="%prog [-w NAME] url | -l")
-    op.add_option("-w", dest="write", metavar="NAME", help="write new sample")
-    op.add_option("-l", dest="list", action="store_true", help="list all samples")
-    opts, args = op.parse_args()
-    if not opts.list and len(args) != 1:
-        op.error("incorrect number of args")
-    return opts, args
+
 
 
 def list_samples():


### PR DESCRIPTION
Clean up test suite by removing obsolete parse_opts configuration parameters.